### PR TITLE
Fixed evaluate_metrics fn when Y DataFrame with both catgs and cont factors is manipulated before function call

### DIFF
--- a/src/pyoptex/doe/cost_optimal/evaluate.py
+++ b/src/pyoptex/doe/cost_optimal/evaluate.py
@@ -91,7 +91,7 @@ def fraction_of_design_space(Y, params, N=10000):
 
     # Transform Y to numpy
     col_names = [str(f.name) for f in params.factors]
-    Y = Y[col_names].to_numpy()
+    Y = Y[col_names].astype(float).to_numpy()
 
     # Encode the design
     Y = encode_design(Y, params.effect_types, params.coords)
@@ -208,7 +208,7 @@ def estimation_variance_matrix(Y, params):
 
     # Transform Y to numpy
     col_names = [str(f.name) for f in params.factors]
-    Y = Y[col_names].to_numpy()
+    Y = Y[col_names].astype(float).to_numpy()
 
     # Encode the design
     Y = encode_design(Y, params.effect_types, params.coords)

--- a/src/pyoptex/doe/cost_optimal/evaluate.py
+++ b/src/pyoptex/doe/cost_optimal/evaluate.py
@@ -41,7 +41,7 @@ def evaluate_metrics(Y, params, metrics):
 
     # Transform Y to numpy
     col_names = [str(f.name) for f in params.factors]
-    Y = Y[col_names].to_numpy()
+    Y = Y[col_names].astype(float).to_numpy()
 
     # Encode the design
     Y = encode_design(Y, params.effect_types, params.coords)

--- a/src/pyoptex/doe/fixed_structure/evaluate.py
+++ b/src/pyoptex/doe/fixed_structure/evaluate.py
@@ -40,7 +40,7 @@ def evaluate_metrics(Y, params, metrics):
 
     # Transform Y to numpy
     col_names = [str(f.name) for f in params.factors]
-    Y = Y[col_names].to_numpy()
+    Y = Y[col_names].astype(float).to_numpy()
 
     # Encode the design
     Y = encode_design(Y, params.effect_types, params.coords)
@@ -85,7 +85,7 @@ def fraction_of_design_space(Y, params, N=10000):
 
     # Transform Y to numpy
     col_names = [str(f.name) for f in params.factors]
-    Y = Y[col_names].to_numpy()
+    Y = Y[col_names].astype(float).to_numpy()
 
     # Encode the design
     Y = encode_design(Y, params.effect_types, params.coords)
@@ -195,7 +195,7 @@ def estimation_variance_matrix(Y, params):
 
     # Transform Y to numpy
     col_names = [str(f.name) for f in params.factors]
-    Y = Y[col_names].to_numpy()
+    Y = Y[col_names].astype(float).to_numpy()
 
     # Encode the design
     Y = encode_design(Y, params.effect_types, params.coords)

--- a/src/pyoptex/doe/utils/evaluate.py
+++ b/src/pyoptex/doe/utils/evaluate.py
@@ -115,7 +115,7 @@ def correlation_map(Y, factors, Y2X, model=None, method='pearson'):
 
     # Transform Y to numpy
     col_names = [str(f.name) for f in factors]
-    Y = Y[col_names].to_numpy()
+    Y = Y[col_names].astype(float).to_numpy()
 
     # Encode the design
     Y = encode_design(Y, effect_types, coords)


### PR DESCRIPTION
Fixes #13 

When a denormalized Y dataframe containing both categoricals and continuous factors is manipulated by user of pyoptex before calling evaluate_metrics through converting to numpy and back, it can happen that a dataframe with columns of dtype object are generated. Categorical factors columns are reverted back to dtype int, but continuous factor columns are not, leading to the creating of an numpy array of type object in line 44, leading to an error in encode_design fn. 

This is fixed by forcing conversion of dataframe to numpy array as array of type float.