### PR TITLE
Carry over computed skipn variable to other functions when set to auto

### DIFF
--- a/src/pyoptex/analysis/estimators/sams/estimator.py
+++ b/src/pyoptex/analysis/estimators/sams/estimator.py
@@ -494,12 +494,12 @@ class SamsRegressor(MultiRegressionMixin):
 
             # Extract the skip
             if len(bkps) == 1:
-                skipn = 0
+                self.skipn = 0
             else:
                 # Take the last breakpoint
-                skipn = bkps[-2] + int(0.01*(len(results) - bkps[-2])) # Add a safety margin for steady state
-        else:
-            skipn = self.skipn
+                self.skipn = bkps[-2] + int(0.01*(len(results) - bkps[-2])) # Add a safety margin for steady state
+        
+        skipn = self.skipn
         results = results[skipn:]
 
         # Possibly cluster


### PR DESCRIPTION
See issue #21

If skipn is set to auto, raster plot will return a bug as the computed value is not carried over correctly to here. This is fixed by this commit 