### PR TITLE
Prevent overflow error in accept prob calculation

### DIFF
--- a/src/pyoptex/analysis/estimators/sams/accept.py
+++ b/src/pyoptex/analysis/estimators/sams/accept.py
@@ -120,7 +120,7 @@ class ExponentialAccept:
             return 1.0
 
         val = -d / self.T
-        if val < -700:  # Clip to avoid overflow
+        if val < -700:  # Clip to avoid underflow; np.exp is effectively 0 for val < -700
             return 0.0
         return np.exp(val)
 

--- a/src/pyoptex/analysis/estimators/sams/accept.py
+++ b/src/pyoptex/analysis/estimators/sams/accept.py
@@ -116,7 +116,13 @@ class ExponentialAccept:
         prob : float
             The acceptance probability.
         """
-        return np.exp(-d / self.T)
+        if d <= 0:  # New solution is better (or equal), accept with prob 1
+            return 1.0
+
+        val = -d / self.T
+        if val < -700:  # Clip to avoid overflow
+            return 0.0
+        return np.exp(val)
 
     def accepted(self):
         """


### PR DESCRIPTION
See issue #25 

Returns 0 if -d/self.T is extremely negative, to prevent overflow error. 
Also returns 1 if d <= 0