### PR TITLE
Added windows mp warning; bugfix in initializing with custom categori…

### DIFF
--- a/docs/source/_docs/doe/performance.rst
+++ b/docs/source/_docs/doe/performance.rst
@@ -57,6 +57,10 @@ should be used, the `ncores` argument can be passed to the
     the :py:func:`set_nb_cores <pyoptex.utils.runtime.set_nb_cores>` function before
     any import. See :ref:`perf_single_core` for more information.
 
+.. warning::
+    On Windows, make sure to wrap your entire code in ``if __name__ == '__main__':`` to avoid
+    an infinite loop of processes. Windows creates processes differently than Linux or MacOS.
+
 .. _perf_cost:
 
 Costs

--- a/docs/source/_docs/doe/quickstart.rst
+++ b/docs/source/_docs/doe/quickstart.rst
@@ -754,6 +754,10 @@ should be used, the `ncores` argument can be passed to the
 
 which will parallelize the number of iterations over exactly 2 cores.
 
+.. warning::
+    On Windows, make sure to wrap your entire code in ``if __name__ == '__main__':`` to avoid
+    an infinite loop of processes. Windows creates processes differently than Linux or MacOS.
+
 An example for split-plot designs can be found at 
 |link-qc-pre|\ |version|\ |link-qc-mid0|\ example_splitplot_multiprocessing.py\ |link-qc-mid1|\ example_splitplot_multiprocessing.py\ |link-qc-post|
 and an example for cost-optimal designs can be found at

--- a/examples/doe/quickstart/example_cost_optimal_codex_mp.py
+++ b/examples/doe/quickstart/example_cost_optimal_codex_mp.py
@@ -19,67 +19,71 @@ from pyoptex.doe.cost_optimal.codex import (
     create_cost_optimal_codex_design, default_fn, create_parameters
 )
 
-# Set the seed
-set_seed(42)
+def main():
+    # Set the seed
+    set_seed(42)
 
-# Define the factors
-factors = [
-    Factor('A', type='categorical', levels=['L1', 'L2', 'L3', 'L4']),
-    Factor('E', type='continuous', grouped=False),
-    Factor('F', type='continuous', grouped=False, min=2, max=5),
-    Factor('G', type='continuous', grouped=False),
-]
+    # Define the factors
+    factors = [
+        Factor('A', type='categorical', levels=['L1', 'L2', 'L3', 'L4']),
+        Factor('E', type='continuous', grouped=False),
+        Factor('F', type='continuous', grouped=False, min=2, max=5),
+        Factor('G', type='continuous', grouped=False),
+    ]
 
-# Create a partial response surface model
-model = partial_rsm_names({
-    'A': 'tfi',
-    'E': 'quad',
-    'F': 'quad',
-    'G': 'quad'
-})
-Y2X = model2Y2X(model, factors)
+    # Create a partial response surface model
+    model = partial_rsm_names({
+        'A': 'tfi',
+        'E': 'quad',
+        'F': 'quad',
+        'G': 'quad'
+    })
+    Y2X = model2Y2X(model, factors)
 
-# Define the criterion for optimization
-metric = Iopt()
+    # Define the criterion for optimization
+    metric = Iopt()
 
-# Cost function
-max_transition_cost = 3*4*60
-transition_costs = {
-    'A': 2*60,
-    'E': 1,
-    'F': 1,
-    'G': 1
-}
-execution_cost = 5
-cost_fn = parallel_worker_cost(
-    transition_costs, factors, 
-    max_transition_cost, execution_cost
-)
+    # Cost function
+    max_transition_cost = 3*4*60
+    transition_costs = {
+        'A': 2*60,
+        'E': 1,
+        'F': 1,
+        'G': 1
+    }
+    execution_cost = 5
+    cost_fn = parallel_worker_cost(
+        transition_costs, factors, 
+        max_transition_cost, execution_cost
+    )
 
-#######################################################################
+    #######################################################################
 
-# Simulation parameters
-nsims = 10
-nreps = 10
-fn = default_fn(nsims, factors, cost_fn, metric, Y2X)
-params = create_parameters(factors, fn)
+    # Simulation parameters
+    nsims = 10
+    nreps = 10
+    fn = default_fn(nsims, factors, cost_fn, metric, Y2X)
+    params = create_parameters(factors, fn)
 
-# Create design
-start_time = time.time()
-Y, state = parallel_generation(create_cost_optimal_codex_design, params, nsims=nsims, nreps=nreps)
-# Y, state = create_cost_optimal_codex_design(
-#     params, nsims=nsims, nreps=nreps
-# )
-end_time = time.time()
+    # Create design
+    start_time = time.time()
+    Y, state = parallel_generation(create_cost_optimal_codex_design, params, nsims=nsims, nreps=nreps)
+    # Y, state = create_cost_optimal_codex_design(
+    #     params, nsims=nsims, nreps=nreps
+    # )
+    end_time = time.time()
 
-#######################################################################
+    #######################################################################
 
-# Write design to storage
-root = os.path.split(__file__)[0]
-Y.to_csv(os.path.join(root, f'example_cost_optimal_codex_mp.csv'), index=False)
+    # Write design to storage
+    root = os.path.split(__file__)[0]
+    Y.to_csv(os.path.join(root, f'example_cost_optimal_codex_mp.csv'), index=False)
 
-print('Completed optimization')
-print(f'Metric: {state.metric:.3f}')
-print(f'Cost: {state.cost_Y}')
-print(f'Number of experiments: {len(state.Y)}')
-print(f'Execution time: {end_time - start_time:.3f}')
+    print('Completed optimization')
+    print(f'Metric: {state.metric:.3f}')
+    print(f'Cost: {state.cost_Y}')
+    print(f'Number of experiments: {len(state.Y)}')
+    print(f'Execution time: {end_time - start_time:.3f}')
+
+if __name__ == '__main__':
+    main()

--- a/examples/doe/quickstart/example_splitplot_multiprocessing.py
+++ b/examples/doe/quickstart/example_splitplot_multiprocessing.py
@@ -19,55 +19,59 @@ from pyoptex.doe.fixed_structure.splitk_plot import (
 )
 from pyoptex.doe.fixed_structure.splitk_plot.metric import Dopt
 
-# Set the seed
-set_seed(42)
+def main():
+    # Set the seed
+    set_seed(42)
 
-# Define the plots
-etc = Plot(level=0, size=4)
-htc = Plot(level=1, size=5, ratio=0.1)
-plots = [etc, htc]
-nruns = np.prod([p.size for p in plots])
+    # Define the plots
+    etc = Plot(level=0, size=4)
+    htc = Plot(level=1, size=5, ratio=0.1)
+    plots = [etc, htc]
+    nruns = np.prod([p.size for p in plots])
 
-# Define the factors
-factors = [
-    Factor('A', htc, type='categorical', levels=['L1', 'L2', 'L3']),
-    Factor('B', etc, type='continuous'),
-    Factor('C', etc, type='continuous', min=2, max=5),
-]
+    # Define the factors
+    factors = [
+        Factor('A', htc, type='categorical', levels=['L1', 'L2', 'L3'], coords=[[1, 0], [0, 1], [0, 0]]),
+        Factor('B', etc, type='continuous'),
+        Factor('C', etc, type='continuous', min=2, max=5),
+    ]
 
-# Create a partial response surface model
-model = partial_rsm_names({
-    'A': 'tfi',
-    'B': 'quad',
-    'C': 'quad',
-})
-Y2X = model2Y2X(model, factors)
+    # Create a partial response surface model
+    model = partial_rsm_names({
+        'A': 'tfi',
+        'B': 'quad',
+        'C': 'quad',
+    })
+    Y2X = model2Y2X(model, factors)
 
-# Define the metric
-metric = Dopt()
+    # Define the metric
+    metric = Dopt()
 
-#########################################################################
+    #########################################################################
 
-# Parameter initialization
-n_tries = 1000
+    # Parameter initialization
+    n_tries = 1000
 
-# Create the set of operators
-fn = default_fn(factors, metric, Y2X)
-params = create_parameters(factors, fn)
+    # Create the set of operators
+    fn = default_fn(factors, metric, Y2X)
+    params = create_parameters(factors, fn)
 
-# Create design
-start_time = time.time()
-Y, state = parallel_generation(create_splitk_plot_design, params, n_tries=n_tries)
-# Y, state = create_splitk_plot_design(params, n_tries=n_tries)
-end_time = time.time()
+    # Create design
+    start_time = time.time()
+    Y, state = parallel_generation(create_splitk_plot_design, params, n_tries=n_tries)
+    # Y, state = create_splitk_plot_design(params, n_tries=n_tries)
+    end_time = time.time()
 
-#########################################################################
+    #########################################################################
 
-# Write design to storage
-root = os.path.split(__file__)[0]
-Y.to_csv(os.path.join(root, 'example_splitplot_multiprocessing.csv'), index=False)
+    # Write design to storage
+    root = os.path.split(__file__)[0]
+    Y.to_csv(os.path.join(root, 'example_splitplot_multiprocessing.csv'), index=False)
 
-print('Completed optimization')
-print(f'Metric: {state.metric:.3f}')
-print(f'Execution time: {end_time - start_time:.3f}')
-print(Y)
+    print('Completed optimization')
+    print(f'Metric: {state.metric:.3f}')
+    print(f'Execution time: {end_time - start_time:.3f}')
+    print(Y)
+
+if __name__ == '__main__':
+    main()

--- a/src/pyoptex/__init__.py
+++ b/src/pyoptex/__init__.py
@@ -1,2 +1,2 @@
 # Define the version number
-__version__ = "1.1.2"
+__version__ = "1.1.3"

--- a/src/pyoptex/doe/cost_optimal/init.py
+++ b/src/pyoptex/doe/cost_optimal/init.py
@@ -86,7 +86,8 @@ def init(params, n=1, complete=False):
 
     # Adjust for completeness
     if complete:
-        coords = None
+        # Must still use the correct categorical encoding
+        coords = [None if f.is_continuous else params.coords[i] for i, f in enumerate(params.factors)]
     else:
         nprior = len(params.prior)
         run[:nprior] = params.prior

--- a/src/pyoptex/doe/fixed_structure/init.py
+++ b/src/pyoptex/doe/fixed_structure/init.py
@@ -63,7 +63,7 @@ def initialize_feasible(params, complete=False, max_tries=1000):
         )
         
         # Encode the design
-        Yenc = encode_design(Y, params.effect_types)
+        Yenc = encode_design(Y, params.effect_types, params.coords)
 
         # Make sure it's feasible
         Xenc = params.fn.Y2X(Yenc)
@@ -109,7 +109,8 @@ def init_random(params, n=1, complete=False):
 
     # Adjust for completeness
     if complete:
-        coords = None
+        # Must still use the correct categorical encoding
+        coords = [None if f.is_continuous else params.coords[i] for i, f in enumerate(params.factors)]
     else:
         coords = params.coords
 

--- a/src/pyoptex/doe/fixed_structure/splitk_plot/init.py
+++ b/src/pyoptex/doe/fixed_structure/splitk_plot/init.py
@@ -64,7 +64,7 @@ def initialize_feasible(params, complete=False, max_tries=1000):
         )
 
         # Encode the design
-        Yenc = encode_design(Y, params.effect_types)
+        Yenc = encode_design(Y, params.effect_types, params.coords)
 
         # Make sure it's feasible
         Xenc = params.fn.Y2X(Yenc)

--- a/src/pyoptex/doe/utils/_init_cy.pyx
+++ b/src/pyoptex/doe/utils/_init_cy.pyx
@@ -24,14 +24,15 @@ def init_single_unconstrained_cython_impl(
     cdef long long n_factors = colstart.size - 1
     cdef Py_ssize_t n_runs = run_view.shape[0]
 
-    if coords is None:
-        # Continuous sampling
-        for i in range(n_factors):
-            # Extract parameters
-            factor_type = effect_types[i]
-            start_col = colstart[i]
-            end_col = colstart[i+1]
-            
+    for i in range(n_factors):
+        # Extract parameters
+        factor_type = effect_types[i]
+        start_col = colstart[i]
+        end_col = colstart[i+1]
+
+        # Check if coordinates exist
+        if coords is None or coords[i] is None:
+            # Default coordinate generation
             if factor_type == 1: 
                 # Continuous factor
                 random_values = np.random.rand(n_runs) * 2.0 - 1.0
@@ -44,37 +45,15 @@ def init_single_unconstrained_cython_impl(
                         run_view[j, start_col:end_col] = -1.0
                     else:
                         run_view[j, start_col + lvls[j]] = 1.0
-    else:
-        for i in range(n_factors):
-            # Extract parameters
-            factor_type = effect_types[i]
-            start_col = colstart[i]
-            end_col = colstart[i+1]
+        else:
+            # Generate based on coordinates
+            # Determine the choices
+            choices = coords[i]
 
-            # Check if coordinates exist
-            if coords[i] is None:
-                # Default coordinate generation
-                if factor_type == 1: 
-                    # Continuous factor
-                    random_values = np.random.rand(n_runs) * 2.0 - 1.0
-                    run_view[:, start_col] = random_values
-                else: 
-                    # Categorical factor
-                    lvls = np.random.randint(factor_type, size=n_runs, dtype=np.int64)              
-                    for j in range(n_runs):
-                        if lvls[j] == factor_type - 1:
-                            run_view[j, start_col:end_col] = -1.0
-                        else:
-                            run_view[j, start_col + lvls[j]] = 1.0
-            else:
-                # Generate based on coordinates
-                # Determine the choices
-                choices = coords[i]
-
-                # Generate random sampling
-                lvls = np.random.randint(choices.shape[0], size=n_runs, dtype=np.int64)
-                for j in range(n_runs):
-                    run_view[j, start_col:end_col] = choices[lvls[j]]
+            # Generate random sampling
+            lvls = np.random.randint(choices.shape[0], size=n_runs, dtype=np.int64)
+            for j in range(n_runs):
+                run_view[j, start_col:end_col] = choices[lvls[j]]
 
     return run_view
 

--- a/src/pyoptex/doe/utils/_init_cy.pyx
+++ b/src/pyoptex/doe/utils/_init_cy.pyx
@@ -51,13 +51,30 @@ def init_single_unconstrained_cython_impl(
             start_col = colstart[i]
             end_col = colstart[i+1]
 
-            # Determine the choices
-            choices = coords[i]
+            # Check if coordinates exist
+            if coords[i] is None:
+                # Default coordinate generation
+                if factor_type == 1: 
+                    # Continuous factor
+                    random_values = np.random.rand(n_runs) * 2.0 - 1.0
+                    run_view[:, start_col] = random_values
+                else: 
+                    # Categorical factor
+                    lvls = np.random.randint(factor_type, size=n_runs, dtype=np.int64)              
+                    for j in range(n_runs):
+                        if lvls[j] == factor_type - 1:
+                            run_view[j, start_col:end_col] = -1.0
+                        else:
+                            run_view[j, start_col + lvls[j]] = 1.0
+            else:
+                # Generate based on coordinates
+                # Determine the choices
+                choices = coords[i]
 
-            # Generate random sampling
-            lvls = np.random.randint(choices.shape[0], size=n_runs, dtype=np.int64)
-            for j in range(n_runs):
-                run_view[j, start_col:end_col] = choices[lvls[j]]
-    
+                # Generate random sampling
+                lvls = np.random.randint(choices.shape[0], size=n_runs, dtype=np.int64)
+                for j in range(n_runs):
+                    run_view[j, start_col:end_col] = choices[lvls[j]]
+
     return run_view
 


### PR DESCRIPTION
**Windows multiprocessing:** Document that on Windows the script must be run under if `__name__ == '__main__':` to avoid process spawn issues, and update multiprocessing examples to use that pattern.

**Bugfix – custom categorical encoding in init:** When initializing with complete=True, coords was set to None, so custom categorical encodings were ignored. Init logic now keeps the correct coords for categorical factors in both cost-optimal and fixed-structure design generation.

**Bugfix – custom categorical in split-plot:** encode_design was called without params.coords in fixed-structure and splitk_plot init; it now receives params.coords so custom categorical encoding is applied.

**Cython init:** _init_cy.pyx now supports both default encoding (when coords[i] is None) and custom coordinates for categorical factors.