### PR TITLE
1.2.x

### DIFF
--- a/src/pyoptex/__init__.py
+++ b/src/pyoptex/__init__.py
@@ -1,2 +1,2 @@
 # Define the version number
-__version__ = "1.2.0"
+__version__ = "1.2.1"

--- a/src/pyoptex/doe/cost_optimal/cov.py
+++ b/src/pyoptex/doe/cost_optimal/cov.py
@@ -38,7 +38,7 @@ def _update_woodbury(Vinv, new_Zs, new_ratios):
     assert len(new_Zs) == new_ratios.shape[1], "Every grouping requires a ratio"
 
     # Convert to expanded format
-    new_Zs = [np.eye(Zi[-1] + 1, dtype=np.bool_)[Zi] for Zi in new_Zs]
+    new_Zs = [np.eye(np.max(Zi) + 1, dtype=np.bool_)[Zi] for Zi in new_Zs]
 
     # Apply each Zs sequentially
     for i in range(len(new_Zs)):

--- a/src/pyoptex/doe/fixed_structure/utils.py
+++ b/src/pyoptex/doe/fixed_structure/utils.py
@@ -39,7 +39,7 @@ class RandomEffect(__RandomEffect__):
         if len(Z) == max_Z + 1 and len(np.unique(Z)) == len(Z):
             raise ValueError(
                 "Z must not assign a distinct random level to every run (e.g. np.arange(n)), because that "
-                "duplicates the observation-level random error already included in the fixed_structure "
+                "duplicates the observation-level random error already included in the "
                 "covariance. Use a coarser grouping or omit this random effect."
             )
 

--- a/src/pyoptex/doe/fixed_structure/utils.py
+++ b/src/pyoptex/doe/fixed_structure/utils.py
@@ -34,6 +34,15 @@ class RandomEffect(__RandomEffect__):
             "The Z array must contain all integers in the interval [0, np.max(Z)]"
         )
 
+        # One distinct random level per run (e.g. Z = np.arange(n)) expands to the identity in obs_var_from_Zs,
+        # which is collinear with the observation-level error term already included as I in V.
+        if len(Z) == max_Z + 1 and len(np.unique(Z)) == len(Z):
+            raise ValueError(
+                "Z must not assign a distinct random level to every run (e.g. np.arange(n)), because that "
+                "duplicates the observation-level random error already included in the fixed_structure "
+                "covariance. Use a coarser grouping or omit this random effect."
+            )
+
         # Assert ratios
         if isinstance(self.ratio, (tuple, list, np.ndarray)):
             assert all(r >= 0 for r in self.ratio), (

--- a/src/pyoptex/utils/design.py
+++ b/src/pyoptex/utils/design.py
@@ -62,7 +62,9 @@ def obs_var_from_Zs(Zs, N, ratios=None, include_error=True):
 
     return V + sum(
         r * (Zi_expanded @ Zi_expanded.T)
-        for r, Zi_expanded in ((r, np.eye(Zi[-1] + 1)[Zi]) for r, Zi in zip(ratios, Zs, strict=True) if Zi is not None)
+        for r, Zi_expanded in (
+            (r, np.eye(np.max(Zi) + 1)[Zi]) for r, Zi in zip(ratios, Zs, strict=True) if Zi is not None
+        )
     )
 
 


### PR DESCRIPTION
* Bugfix to use max Zi instead of last element in obs_var_from_Zs and woodbury formula
* Fixed structure random effect grouping check. Make sure it is not collinear to the random error.