### PR TITLE
Make model_size mean s_max directly; expose oversized_model_size; fix BnB ceiling off-by-two

### DIFF
--- a/src/pyoptex/analysis/estimators/sams/entropy.py
+++ b/src/pyoptex/analysis/estimators/sams/entropy.py
@@ -10,7 +10,7 @@ from ....utils.model import sample_model_dep_onebyone
 
 
 def entropies_approx(
-    submodels, freqs, model_size, dep, mode, forced=None, N=10000, sampler=sample_model_dep_onebyone, eps=1e-6
+    submodels, freqs, oversized_model_size, dep, mode, forced=None, N=10000, sampler=sample_model_dep_onebyone, eps=1e-6
 ):
     """
     Compute the approximate entropy by sampling N random models
@@ -33,7 +33,7 @@ def entropies_approx(
         The list of top submodels for each size.
     freqs : np.array(1d)
         The frequencies of these submodels in the raster plot.
-    model_size : int
+    oversized_model_size : int
         The size of the overfitted models.
         The overfitted model includes the forced model,
         and its size must thus be larger than the forced model.
@@ -48,7 +48,7 @@ def entropies_approx(
     N : int
         The number of random samples to draw to compute the
         theoretical frequency of a submodel.
-    sampler : func(dep, model_size, N, forced, mode)
+    sampler : func(dep, oversized_model_size, N, forced, mode)
         The sampler to use when generating random hereditary models.
     eps : float
         A numerical stability parameter in computing the entropy.
@@ -59,7 +59,7 @@ def entropies_approx(
         An array of floats of the same length as the submodels.
     """
     # Generate random samples
-    samples = sampler(dep, model_size, N, forced, mode)
+    samples = sampler(dep, oversized_model_size, N, forced, mode)
 
     # Convert samples to a boolean array
     samples = int2bool(samples, len(dep))
@@ -85,7 +85,7 @@ def entropies_approx(
     return entropies
 
 
-def count_models(max_model, model_size, model=None):
+def count_models(max_model, oversized_model_size, model=None):
     """
     Counts the number of models of a given size in the max model
     assuming weak heredity.
@@ -98,7 +98,7 @@ def count_models(max_model, model_size, model=None):
     max_model : (n_main, n_tfi, n_quad)
         The number of main, tfi and quadratic effects in the main model.
         Each time the total amount.
-    model_size : int
+    oversized_model_size : int
         The size of the overfitted models.
     model : (me_pp, me_pm, me_mm, mtfi, mquad)
         The submodel parameters.
@@ -130,24 +130,24 @@ def count_models(max_model, model_size, model=None):
 
     # Count models
     count = 0
-    for ypp in range(0, model_size + 1 - terms):
+    for ypp in range(0, oversized_model_size + 1 - terms):
         p1 = comb(wpp - me_pp, ypp)
-        for ypm in range(1 if me == 0 and ypp == 0 else 0, model_size + 1 - terms - ypp):
+        for ypm in range(1 if me == 0 and ypp == 0 else 0, oversized_model_size + 1 - terms - ypp):
             p2 = comb(wpm - me_pm, ypm)
-            for ymm in range(0, model_size + 1 - terms - ypp - ypm):
+            for ymm in range(0, oversized_model_size + 1 - terms - ypp - ypm):
                 p3 = comb(wmm - me_mm, ymm)
                 y1 = ypp + ypm + ymm
                 for y2 in range(0, me_pp + ypp - mquad + 1):
                     p4 = comb(me_pp + ypp - mquad, y2)
                     P = (ypp + ypm) * (wpp + wpm - me_pp - me_pm - 1) - comb(ypp + ypm, 2)
                     Q = (me_pp + me_pm) * (wpp + wpm - 1) - comb(me_pp + me_pm, 2) - mtfi
-                    p5 = comb(P + Q, model_size - terms - y1 - y2)
+                    p5 = comb(P + Q, oversized_model_size - terms - y1 - y2)
                     count += p1 * p2 * p3 * p4 * p5
 
     return count
 
 
-def entropies(submodels, freqs, model_size, max_model, eps=1e-6):
+def entropies(submodels, freqs, oversized_model_size, max_model, eps=1e-6):
     """
     Compute the entropies of the submodels given the total set of models.
     Please read the warning in the documentation on customizing SAMS.
@@ -162,7 +162,7 @@ def entropies(submodels, freqs, model_size, max_model, eps=1e-6):
         The submodels to compute the entropy for
     freqs : np.array(1d)
         An array of (observed) frequencies from each submodel
-    model_size : int
+    oversized_model_size : int
         The size of the overfitted models.
         The overfitted model includes the forced model.
     max_model : (nquad, ntwo, nlin)
@@ -185,7 +185,7 @@ def entropies(submodels, freqs, model_size, max_model, eps=1e-6):
     max_model = (nmain + 1, nint, nquad)
 
     # Count total number of models
-    ct = count_models(max_model, model_size)
+    ct = count_models(max_model, oversized_model_size)
 
     # Initialize entropies
     entropies = np.empty(len(submodels), dtype=np.float64)
@@ -203,7 +203,7 @@ def entropies(submodels, freqs, model_size, max_model, eps=1e-6):
         model = (me_pp, me_pm, me_mm, mtfi, mquad)
 
         # Theoretical frequency
-        theoretical_freq = count_models(max_model, model_size, model) / ct
+        theoretical_freq = count_models(max_model, oversized_model_size, model) / ct
 
         # Observed frequency
         obs_freq = freqs[i]

--- a/src/pyoptex/analysis/estimators/sams/estimator.py
+++ b/src/pyoptex/analysis/estimators/sams/estimator.py
@@ -352,17 +352,6 @@ class SamsRegressor(MultiRegressionMixin):
             "(s_max): the search cannot distil a model larger than the "
             "oversized models it explores."
         )
-        assert self._oversized_model_size <= self.n_encoded_features_, (
-            f"oversized_model_size ({self._oversized_model_size}) cannot exceed "
-            f"the number of candidate features ({self.n_encoded_features_})."
-        )
-        capacity_bound = min(self.n_encoded_features_, len(X))
-        assert self._oversized_model_size <= capacity_bound, (
-            f"oversized_model_size ({self._oversized_model_size}) cannot exceed "
-            f"min(candidate features {self.n_encoded_features_}, runs {len(X)}) "
-            f"= {capacity_bound}. This is a coarse bound; estimable capacity may "
-            f"be lower still in split-plot designs."
-        )
         forced_len = len(self.forced_model) if self.forced_model is not None else 0
         for size in self._nterms_bnb:
             assert forced_len < size <= self._oversized_model_size, (
@@ -584,6 +573,17 @@ class SamsRegressor(MultiRegressionMixin):
         # Some final validation
         assert np.all(self.forced_model < self.n_encoded_features_), (
             "The forced model must have integers smaller than the number of parameters in X"
+        )
+        assert self._oversized_model_size <= self.n_encoded_features_, (
+            f"oversized_model_size ({self._oversized_model_size}) cannot exceed "
+            f"the number of candidate features ({self.n_encoded_features_})."
+        )
+        capacity_bound = min(self.n_encoded_features_, len(X))
+        assert self._oversized_model_size <= capacity_bound, (
+            f"oversized_model_size ({self._oversized_model_size}) cannot exceed "
+            f"min(candidate features {self.n_encoded_features_}, runs {len(X)}) "
+            f"= {capacity_bound}. This is a coarse bound; estimable capacity may "
+            f"be lower still in split-plot designs."
         )
         if self.mode is not None:
             assert self.dependencies.shape[0] == X.shape[1], "Must specify a dependency for each term"

--- a/src/pyoptex/analysis/estimators/sams/estimator.py
+++ b/src/pyoptex/analysis/estimators/sams/estimator.py
@@ -299,14 +299,12 @@ class SamsRegressor(MultiRegressionMixin):
             self._oversized_model_size = self._s_max + 2
 
         forced_len = len(self.forced_model) if self.forced_model is not None else 0
-        self._nterms_bnb = (
+        self._nterms_bnb = list(
             range(forced_len + 1, self._s_max + 1)
             if self.nterms_bnb is None
-            else (
-                range(forced_len + 1, self.nterms_bnb + 1)
-                if isinstance(self.nterms_bnb, int)
-                else self.nterms_bnb
-            )
+            else (range(forced_len + 1, self.nterms_bnb + 1)
+                  if isinstance(self.nterms_bnb, int)
+                  else self.nterms_bnb)
         )
         self._est_ratios = np.ones(len(self._re)) if len(self._re) > 0 and self.est_ratios is None else self.est_ratios
 
@@ -333,6 +331,15 @@ class SamsRegressor(MultiRegressionMixin):
         # TODO: validate forced_model hereditary
 
         # Validate SAMS inputs
+        if self.model_size is not None:
+            assert isinstance(self.model_size, (int, np.integer)), (
+                "model_size must be an integer"
+            )
+        if self.oversized_model_size is not None:
+            assert isinstance(self.oversized_model_size, (int, np.integer)), (
+                "oversized_model_size must be an integer"
+            )
+
         if self._s_max is not None:
             if self.forced_model is None:
                 assert self._s_max > 0, "The model size (s_max) must be a positive number"
@@ -345,6 +352,24 @@ class SamsRegressor(MultiRegressionMixin):
             "(s_max): the search cannot distil a model larger than the "
             "oversized models it explores."
         )
+        assert self._oversized_model_size <= self.n_encoded_features_, (
+            f"oversized_model_size ({self._oversized_model_size}) cannot exceed "
+            f"the number of candidate features ({self.n_encoded_features_})."
+        )
+        capacity_bound = min(self.n_encoded_features_, len(X))
+        assert self._oversized_model_size <= capacity_bound, (
+            f"oversized_model_size ({self._oversized_model_size}) cannot exceed "
+            f"min(candidate features {self.n_encoded_features_}, runs {len(X)}) "
+            f"= {capacity_bound}. This is a coarse bound; estimable capacity may "
+            f"be lower still in split-plot designs."
+        )
+        forced_len = len(self.forced_model) if self.forced_model is not None else 0
+        for size in self._nterms_bnb:
+            assert forced_len < size <= self._oversized_model_size, (
+                f"BnB submodel size {size} must be greater than the forced-model "
+                f"size ({forced_len}) and at most oversized_model_size "
+                f"({self._oversized_model_size})."
+            )
         assert self.nb_models == "all" or self.nb_models > 0, (
             'Must have at least one model to simulate, nb_models must be larger than zero or "all"'
         )

--- a/src/pyoptex/analysis/estimators/sams/estimator.py
+++ b/src/pyoptex/analysis/estimators/sams/estimator.py
@@ -145,7 +145,7 @@ class SamsRegressor(MultiRegressionMixin):
         random_effects=(),
         dependencies=None,
         mode=None,
-        forced_model=None,
+        forced_model=np.array([0]),
         model_size=None,
         oversized_model_size=None,
         nb_models=10000,
@@ -298,11 +298,12 @@ class SamsRegressor(MultiRegressionMixin):
             self._s_max = len(X) // 3
             self._oversized_model_size = self._s_max + 2
 
+        forced_len = len(self.forced_model) if self.forced_model is not None else 0
         self._nterms_bnb = (
-            range(len(self.forced_model) + 1, self._s_max + 1)
+            range(forced_len + 1, self._s_max + 1)
             if self.nterms_bnb is None
             else (
-                range(len(self.forced_model) + 1, self.nterms_bnb + 1)
+                range(forced_len + 1, self.nterms_bnb + 1)
                 if isinstance(self.nterms_bnb, int)
                 else self.nterms_bnb
             )

--- a/src/pyoptex/analysis/estimators/sams/estimator.py
+++ b/src/pyoptex/analysis/estimators/sams/estimator.py
@@ -53,9 +53,12 @@ class SamsRegressor(MultiRegressionMixin):
         the normalized, encoded model matrix. This model must itself fulfill the
         heredity constraints.
     model_size : int
-        The size of the overfitted models. Defaults to the number of runs
-        divided by three. The overfitted model includes the forced model,
-        and its size must thus be larger than the forced model.
+        The maximum size of the models SAMS aims to identify — the largest
+        plausible size of the true model (s_max in Wolters & Bingham, 2011).
+        A good-model set of slightly larger, overfitted models is collected,
+        and candidate models of size up to model_size are distilled from it.
+        Must exceed the forced-model size, since every model contains the
+        forced terms. Defaults to n_runs // 3.
     nb_models : int or 'all'
         The number of unique models to accept during the sams procedure.
         If 'all' then all possible models are fitted.
@@ -86,11 +89,12 @@ class SamsRegressor(MultiRegressionMixin):
         The number of top submodels for a fixed size to retrieve for entropy
         calculations.
     nterms_bnb : None or int or iterable(int)
-        The fixed sizes of submodels to apply the branch-and-bound algorithm
-        on. If None, every size from one to the `model_size` - 2 (inclusive) is tested
-        as recommended by the original paper. If an int, every size from
-        one until the specified number is tested. If an iterable, only the
-        values from the iterable are tested.
+        The submodel sizes at which the branch-and-bound search is run.
+        If None, every size from just above the forced-model size up to
+        `model_size` (inclusive) is searched, following Wolters & Bingham
+        (2011). If an int, every size from above the forced model up to and
+        including the given value is searched. If an iterable, only the
+        listed sizes are searched.
     bnb_timeout : int
         The maximum number of seconds to run the branch-and-bound algorithm for.
         Clear submodels in the raster plot will not require much time in
@@ -98,7 +102,7 @@ class SamsRegressor(MultiRegressionMixin):
         algorithm would require too much time, most likely low entropy models
         are the result and the computation can be halted prematurely. Defaults
         to three minutes.
-    entropy_sampler : func(dep, model_size, N, forced, mode)
+    entropy_sampler : func(dep, oversized_model_size, N, forced, mode)
         The sampler to use when generating random hereditary models. See the
         documentation on customizing SAMS for an indication on which sampler to use.
     entropy_sampling_N : int
@@ -113,7 +117,7 @@ class SamsRegressor(MultiRegressionMixin):
         A SAMS model used in sampling and fitting data during the SAMS procedure.
     results\\_ : np.array(1d)
         A numpy array with a special datatype where each element contains
-        two arrays of size `model_size` ('model', np.int64), ('coeff', np.float64),
+        two arrays of size `oversized_model_size` ('model', np.int64), ('coeff', np.float64),
         and one scalar ('metric', np.float64). Results contains `nb_models` elements.
         These are the returned models from the SAMS procedure.
     models\\_ : list(np.array(1d))
@@ -143,6 +147,7 @@ class SamsRegressor(MultiRegressionMixin):
         mode=None,
         forced_model=None,
         model_size=None,
+        oversized_model_size=None,
         nb_models=10000,
         skipn="auto",
         est_ratios=None,
@@ -183,9 +188,12 @@ class SamsRegressor(MultiRegressionMixin):
             the normalized, encoded model matrix. This model must itself fulfill the
             heredity constraints.
         model_size : int
-            The size of the overfitted models. Defaults to the number of runs
-            divided by three. The overfitted model includes the forced model,
-            and its size must thus be larger than the forced model.
+            The maximum size of the models SAMS aims to identify — the largest
+            plausible size of the true model (s_max in Wolters & Bingham, 2011).
+            A good-model set of slightly larger, overfitted models is collected,
+            and candidate models of size up to model_size are distilled from it.
+            Must exceed the forced-model size, since every model contains the
+            forced terms. Defaults to n_runs // 3.
         nb_models : int or 'all'
             Th number of unique models to accept during the sams procedure.
             If 'all', then all possible models will be fitted.
@@ -216,11 +224,12 @@ class SamsRegressor(MultiRegressionMixin):
             The number of top submodels for a fixed size to retrieve for entropy
             calculations.
         nterms_bnb : None or int or iterable(int)
-            The fixed sizes of submodels to apply the branch-and-bound algorithm
-            on. If None, every size from one to the `model_size` - 2 (inclusive) is tested
-            as recommended by the original paper. If an int, every size from
-            one until the specified number is tested. If an iterable, only the
-            values from the iterable are tested.
+            The submodel sizes at which the branch-and-bound search is run.
+            If None, every size from just above the forced-model size up to
+            `model_size` (inclusive) is searched, following Wolters & Bingham
+            (2011). If an int, every size from above the forced model up to and
+            including the given value is searched. If an iterable, only the
+            listed sizes are searched.
         bnb_timeout : int
             The maximum number of seconds to run the branch-and-bound algorithm for.
             Clear submodels in the raster plot will not require much time in
@@ -228,7 +237,7 @@ class SamsRegressor(MultiRegressionMixin):
             algorithm would require too much time, most likely low entropy models
             are the result and the computation can be halted prematurely. Defaults
             to three minutes.
-        entropy_sampler : func(dep, model_size, N, forced, mode)
+        entropy_sampler : func(dep, oversized_model_size, N, forced, mode)
             The sampler to use when generating random hereditary models. See the
             documentation on customizing SAMS for an indication on which sampler to use.
         entropy_sampling_N : int
@@ -246,6 +255,7 @@ class SamsRegressor(MultiRegressionMixin):
         self.dependencies = dependencies
         self.mode = mode
         self.model_size = model_size
+        self.oversized_model_size = oversized_model_size
         self.nb_models = nb_models
         self.skipn = skipn
         self.est_ratios = est_ratios
@@ -274,14 +284,28 @@ class SamsRegressor(MultiRegressionMixin):
             The output variable.
         """
         super()._regr_params(X, y)
-        self._model_size = self.model_size if self.model_size is not None else int(len(X) / 3)
 
-        # Set some default values
-        self._nterms_bnb = self._model_size - 1 if self.nterms_bnb is None else self.nterms_bnb
+        if self.model_size is not None and self.oversized_model_size is not None:
+            self._s_max = self.model_size
+            self._oversized_model_size = self.oversized_model_size
+        elif self.model_size is not None:
+            self._s_max = self.model_size
+            self._oversized_model_size = self.model_size + 2
+        elif self.oversized_model_size is not None:
+            self._oversized_model_size = self.oversized_model_size
+            self._s_max = self.oversized_model_size - 2
+        else:
+            self._s_max = len(X) // 3
+            self._oversized_model_size = self._s_max + 2
+
         self._nterms_bnb = (
-            range(len(self.forced_model) + 1, self._nterms_bnb)
-            if isinstance(self._nterms_bnb, int)
-            else self._nterms_bnb
+            range(len(self.forced_model) + 1, self._s_max + 1)
+            if self.nterms_bnb is None
+            else (
+                range(len(self.forced_model) + 1, self.nterms_bnb + 1)
+                if isinstance(self.nterms_bnb, int)
+                else self.nterms_bnb
+            )
         )
         self._est_ratios = np.ones(len(self._re)) if len(self._re) > 0 and self.est_ratios is None else self.est_ratios
 
@@ -308,13 +332,18 @@ class SamsRegressor(MultiRegressionMixin):
         # TODO: validate forced_model hereditary
 
         # Validate SAMS inputs
-        if self.model_size is not None:
+        if self._s_max is not None:
             if self.forced_model is None:
-                assert self.model_size > 0, "The overfitted model size must be a positive number"
+                assert self._s_max > 0, "The model size (s_max) must be a positive number"
             else:
-                assert self.model_size > len(self.forced_model), (
-                    "The overfitted model size must be at least one larger than the forced model"
+                assert self._s_max > len(self.forced_model), (
+                    "model size (s_max) must be at least one larger than the forced model"
                 )
+        assert self._oversized_model_size > self._s_max, (
+            "oversized_model_size must be strictly larger than model_size "
+            "(s_max): the search cannot distil a model larger than the "
+            "oversized models it explores."
+        )
         assert self.nb_models == "all" or self.nb_models > 0, (
             'Must have at least one model to simulate, nb_models must be larger than zero or "all"'
         )
@@ -376,7 +405,7 @@ class SamsRegressor(MultiRegressionMixin):
         ----------
         results : np.array(1d)
             A numpy array with a special datatype where each element contains
-            two arrays of size `model_size` ('model', np.int64), ('coeff', np.float64),
+            two arrays of size `oversized_model_size` ('model', np.int64), ('coeff', np.float64),
             and one scalar ('metric', np.float64). Results contains `nb_models` elements.
         sizes : iterable(int)
             An iterable of ints with the fixed sizes of the submodels.
@@ -495,7 +524,7 @@ class SamsRegressor(MultiRegressionMixin):
             entropy = entropies_approx(
                 submodels,
                 freqs,
-                self._model_size,
+                self._oversized_model_size,
                 self.dependencies,
                 self.mode,
                 self.forced_model,
@@ -511,7 +540,7 @@ class SamsRegressor(MultiRegressionMixin):
             model_counts = [model_counts.get(e, 0) for e in ("quad", "tfi", "lin")]
 
             # Compute entropy (based on model order)
-            entropy = entropies(submodels, freqs, self._model_size, model_counts)
+            entropy = entropies(submodels, freqs, self._oversized_model_size, model_counts)
 
         return entropy
 
@@ -541,11 +570,11 @@ class SamsRegressor(MultiRegressionMixin):
             self.sams_model_ = MixedLMModel(X, y, forced=self.forced_model, mode=self.mode, dep=self.dependencies, V=V)
         accept = ExponentialAccept(T0=(X.shape[0]) * np.var(y) / 10, rho=0.95, kappa=4)
         if self.nb_models == "all":
-            self.results_ = simulate_all(self.sams_model_, self._model_size, tqdm=self.tqdm)
+            self.results_ = simulate_all(self.sams_model_, self._oversized_model_size, tqdm=self.tqdm)
         else:
             self.results_ = simulate_sams(
                 self.sams_model_,
-                self._model_size,
+                self._oversized_model_size,
                 accept_fn=accept,
                 nb_models=self.nb_models,
                 allow_duplicate=self.allow_duplicate_sample,

--- a/src/pyoptex/analysis/estimators/sams/simulation.py
+++ b/src/pyoptex/analysis/estimators/sams/simulation.py
@@ -8,7 +8,7 @@ from tqdm import tqdm as tqdm_
 from .accept import ExponentialAccept
 
 
-def simulate_sams(model, model_size, accept_fn=None, nb_models=10, minprob=0.01, allow_duplicate=False, tqdm=True):
+def simulate_sams(model, oversized_model_size, accept_fn=None, nb_models=10, minprob=0.01, allow_duplicate=False, tqdm=True):
     """
     Sample models using SAMS algorithm.
 
@@ -16,7 +16,7 @@ def simulate_sams(model, model_size, accept_fn=None, nb_models=10, minprob=0.01,
     ----------
     model : :py:class:`Model <pyoptex.analysis.estimators.sams.models.model.Model>`
         The model to fit such as an OLS or a mixed model.
-    model_size : int
+    oversized_model_size : int
         The total size of each overfitted model.
     accept_fn : func(d)
         The acceptance function. Defaults to the
@@ -34,7 +34,7 @@ def simulate_sams(model, model_size, accept_fn=None, nb_models=10, minprob=0.01,
     -------
     results : np.array(1d)
         A numpy array with a special datatype where each element contains
-        two arrays of size `model_size` ('model', np.int64), ('coeff', np.float64),
+        two arrays of size `oversized_model_size` ('model', np.int64), ('coeff', np.float64),
         and one scalar ('metric', np.float64). Results contains `nb_models` elements.
     """
     # Initialize variables
@@ -44,12 +44,12 @@ def simulate_sams(model, model_size, accept_fn=None, nb_models=10, minprob=0.01,
     accept_fn.reset()
 
     # Initialize model storage
-    rdtype = np.dtype([("model", np.int64, model_size), ("coeff", np.float64, model_size), ("metric", np.float64)])
+    rdtype = np.dtype([("model", np.int64, oversized_model_size), ("coeff", np.float64, oversized_model_size), ("metric", np.float64)])
     results = np.zeros(nb_models, dtype=rdtype)
-    models = np.zeros((nb_models, model_size), dtype=np.int64)
+    models = np.zeros((nb_models, oversized_model_size), dtype=np.int64)
 
     # Create initial model
-    m = np.zeros(model_size, dtype=np.int64)
+    m = np.zeros(oversized_model_size, dtype=np.int64)
     m = model.init(m)
 
     # Compute initial metric
@@ -96,7 +96,7 @@ def simulate_sams(model, model_size, accept_fn=None, nb_models=10, minprob=0.01,
     return results
 
 
-def simulate_all(model, model_size, tqdm=True):
+def simulate_all(model, oversized_model_size, tqdm=True):
     """
     Sample and fits all possible models.
 
@@ -104,7 +104,7 @@ def simulate_all(model, model_size, tqdm=True):
     ----------
     model : :py:class:`Model <pyoptex.analysis.estimators.sams.models.model.Model>`
         The model to fit such as an OLS or a mixed model.
-    model_size : int
+    oversized_model_size : int
         The total size of each overfitted model.
     tqdm : bool
         Whether to use tqdm to track the progress.
@@ -113,15 +113,15 @@ def simulate_all(model, model_size, tqdm=True):
     -------
     results : np.array(1d)
         A numpy array with a special datatype where each element contains
-        two arrays of size `model_size` ('model', np.int64), ('coeff', np.float64),
+        two arrays of size `oversized_model_size` ('model', np.int64), ('coeff', np.float64),
         and one scalar ('metric', np.float64). Results contains `nb_models` elements.
     """
     # Generate all possible model combinations
-    models = model.all(model_size)
+    models = model.all(oversized_model_size)
     nb_models = len(models)
 
     # Initialize model storage
-    rdtype = np.dtype([("model", np.int64, model_size), ("coeff", np.float64, model_size), ("metric", np.float64)])
+    rdtype = np.dtype([("model", np.int64, oversized_model_size), ("coeff", np.float64, oversized_model_size), ("metric", np.float64)])
     results = np.zeros(nb_models, dtype=rdtype)
 
     # Compute the metrics for all

--- a/tests/test_analysis/test_sams_generic.py
+++ b/tests/test_analysis/test_sams_generic.py
@@ -36,7 +36,7 @@ def test_sams_generic():
         dependencies=dependencies,
         mode="weak",
         forced_model=np.array([0], np.int64),
-        model_size=8,
+        model_size=6,
         nb_models=5000,
         skipn=3000,
     )

--- a/tests/test_analysis/test_sams_generic_all.py
+++ b/tests/test_analysis/test_sams_generic_all.py
@@ -36,7 +36,7 @@ def test_sams_generic_all():
         dependencies=dependencies,
         mode="weak",
         forced_model=np.array([0], np.int64),
-        model_size=6,
+        model_size=4,
         nb_models="all",
         skipn=0.7,
     )

--- a/tests/test_analysis/test_sams_partial_rsm.py
+++ b/tests/test_analysis/test_sams_partial_rsm.py
@@ -36,7 +36,7 @@ def test_sams_partial_rsm():
         dependencies=dependencies,
         mode="weak",
         forced_model=np.array([0], np.int64),
-        model_size=8,
+        model_size=6,
         nb_models=5000,
         skipn=3000,
         entropy_model_order=model_order,

--- a/tests/test_analysis/test_sams_partial_rsm_cluster.py
+++ b/tests/test_analysis/test_sams_partial_rsm_cluster.py
@@ -36,7 +36,7 @@ def test_sams_partial_rsm_cluster():
         dependencies=dependencies,
         mode="weak",
         forced_model=np.array([0], np.int64),
-        model_size=8,
+        model_size=6,
         nb_models=5000,
         skipn=3000,
         entropy_model_order=model_order,


### PR DESCRIPTION
Realigns model_size with the size of the identified model (previously the good-model-set size), so the distillation ceiling matches what the user specifies (issue #50 ). Currently model_size is used internally as the oversized (good-model-set) size, while a user intuitively reads it as the maximum size of the model SAMS aims to identify (s_max in Wolters & Bingham). These two differ by the oversizing margin, and the mismatch is the root of the off-by-two.
Proposed change:

model_size now denotes s_max — the maximum distilled/true-model size — matching user intuition and W&B terminology. The oversized good-model-set size is derived internally as s_max + 2.
Adds oversized_model_size as an optional parameter, so the oversized size can still be set independently (preserving the current flexibility). If only oversized_model_size is given, s_max is derived as oversized_model_size - 2; if both are given, they are validated for consistency.

The BnB submodel-size ceiling is now s_max inclusive (range(..., s_max + 1)), fixing the off-by-two.
Renames the internal oversized-size attribute to _oversized_model_size consistently (previously referenced under inconsistent names, which also caused latent AttributeErrors in _fit/_entropy), and corrects the _validate_fit and docstring wording.

Note on backward compatibility: this redefines the meaning of model_size for existing users who currently pass it as the oversized size — their effective search size shifts by the oversizing margin. If you'd prefer a non-breaking route (e.g. adding s_max as a new parameter while leaving model_size as-is, or a deprecation cycle), I'm happy to rework it — this PR is one proposed resolution, not the only one. Flagging for your call since it's an API change.
Verification: on a design with a non-empty forced model, _s_max, _oversized_model_size, and max(_nterms_bnb) now resolve to (s_max, s_max + 2, s_max); previously the last was s_max - 2.