### PR TITLE
Feature: Added warm start initialization (init_warm_feasible) to cost_optimal subpackage

### DIFF
--- a/src/pyoptex/doe/cost_optimal/init.py
+++ b/src/pyoptex/doe/cost_optimal/init.py
@@ -344,7 +344,7 @@ def init_feasible_(params, max_tries=3, minimal=True, max_size=None, force_cost_
 
     return Y
 
-def init_warm_feasible(df, group_col=None, n_keep=None, max_tries=5000):
+def init_warm_feasible(params, df, group_col=None, n_keep=None, max_tries=5000):
     """
     Seed the optimizer from an existing design by keeping a random subset of intact groups.
 
@@ -369,62 +369,69 @@ def init_warm_feasible(df, group_col=None, n_keep=None, max_tries=5000):
     max_tries : int, default=5000
         The maximum number of random draws to attempt before yielding the best 
         infeasible (but full-rank) subset.
+
+    Returns
+    -------
+    Y : np.array(2d)
+        The warm-started initial design subset.
+
+    Example
+    -------
+    >>> init_fn = lambda params: init_warm_feasible(params, df, group_col="day", n_keep=3)
+    >>> fn = default_fn(..., init=init_fn)
     """
-    def _init_warm_feasible(params):
+    Ydf = df.copy()
+    for f in params.factors:
+        Ydf[f.name] = f.normalize(Ydf[f.name])
+    factor_names = [f.name for f in params.factors]
+    Ydec = Ydf[factor_names].to_numpy()
+    Yenc = encode_design(Ydec, params.effect_types, coords=params.coords)
+
+    if group_col is None:
+        group = list(Ydf.index)
+    else:
+        group = Ydf[group_col].to_numpy()
+
+    groups = np.unique(group)
+    k = n_keep if n_keep is not None else max(1, len(groups) // 2)
+    if k >= len(groups):
+        return Yenc                            # nothing to subsample
+
+    pick = list(combinations(groups, n_keep))
+    pick = np.random.permutation(pick)
+
+    tries = min(max_tries, pick.shape[0])
+
+    best, best_cost = None, None
+    for i in tqdm(range(tries)):
+        mask = np.isin(group, pick[i])
+        Yk = Yenc[mask]
+
+        costs = params.fn.cost(Yk, params)
+        cost_Yk = np.array([np.sum(c) for c, _, _ in costs])
+        max_cost = np.array([m for _, m, _ in costs])
+
+        Xk = params.fn.Y2X(Yk)
+        rank = np.linalg.matrix_rank(Xk)
+        feasible = (rank >= Xk.shape[1]) \
+                and (np.all(cost_Yk <= max_cost))
+
+        if feasible:
+            return Yk                            # estimable: done
         
-        Ydf = df.copy()
-        for f in params.factors:
-            Ydf[f.name] = f.normalize(Ydf[f.name])
-        factor_names = [f.name for f in params.factors]
-        Ydec = Ydf[factor_names].to_numpy()
-        Yenc = encode_design(Ydec, params.effect_types, coords=params.coords)
-
-        if group_col is None:
-            group = list(Ydf.index)
-        else:
-            group = Ydf[group_col].to_numpy()
-
-        groups = np.unique(group)
-        k = n_keep if n_keep is not None else max(1, len(groups) // 2)
-        if k >= len(groups):
-            return Yenc                            # nothing to subsample
-
-        pick = list(combinations(groups, n_keep))
-        pick = np.random.permutation(pick)
-
-        tries = min(max_tries, pick.shape[0])
-
-        best, best_cost = None, None
-        for i in tqdm(range(tries)):
-            mask = np.isin(group, pick[i])
-            Yk = Yenc[mask]
-
-            costs = params.fn.cost(Yk, params)
-            cost_Yk = np.array([np.sum(c) for c, _, _ in costs])
-            max_cost = np.array([m for _, m, _ in costs])
-
-            Xk = params.fn.Y2X(Yk)
-            rank = np.linalg.matrix_rank(Xk)
-            feasible = (rank >= Xk.shape[1]) \
-                    and (np.all(cost_Yk <= max_cost))
-
-            if feasible:
-                return Yk                            # estimable: done
-            
-            elif rank >= Xk.shape[1] and (best is None or np.all(cost_Yk[cost_Yk > max_cost] < best_cost)):
-                best, best_cost = Yk, cost_Yk[cost_Yk > max_cost]
+        elif rank >= Xk.shape[1] and (best is None or np.all(cost_Yk[cost_Yk > max_cost] < best_cost)):
+            best, best_cost = Yk, cost_Yk[cost_Yk > max_cost]
 
 
-        # FINAL CHECKS
-        if best is None:
-            raise ValueError(
-                f"No {k}-group subset achieved full rank in {max_tries} draws "
-                f"(need {Xk.shape[1]} params). Cannot warm start. Try a larger n_keep."
-            )
-        
-        warnings.warn(
-            f"no {k}-group subset reached full rank in {max_tries} draws "
-            f"(need {Xk.shape[1]} params); returning largest attempt ({best.shape[0]} runs). "
-            f"Try a larger n_keep.")
-        return best
-    return _init_warm_feasible
+    # FINAL CHECKS
+    if best is None:
+        raise ValueError(
+            f"No {k}-group subset achieved full rank in {max_tries} draws "
+            f"(need {Xk.shape[1]} params). Cannot warm start. Try a larger n_keep."
+        )
+    
+    warnings.warn(
+        f"no {k}-group subset reached full rank in {max_tries} draws "
+        f"(need {Xk.shape[1]} params); returning largest attempt ({best.shape[0]} runs). "
+        f"Try a larger n_keep.")
+    return best

--- a/src/pyoptex/doe/cost_optimal/init.py
+++ b/src/pyoptex/doe/cost_optimal/init.py
@@ -1,10 +1,13 @@
 """
 Module for all init functions of the cost optimal designs
 """
+import warnings
+from itertools import combinations
 
 import numpy as np
 from tqdm import tqdm
 
+from ...utils.design import encode_design
 from ..utils.init import full_factorial, init_single_unconstrained
 
 
@@ -340,3 +343,88 @@ def init_feasible_(params, max_tries=3, minimal=True, max_size=None, force_cost_
             )
 
     return Y
+
+def init_warm_feasible(df, group_col=None, n_keep=None, max_tries=5000):
+    """
+    Seed the optimizer from an existing design by keeping a random subset of intact groups.
+
+    Sampling by group (rather than by individual rows) can ensure that hard-to-change factor
+    settings remain together. However, because feasibility and estimability are not guaranteed
+    by a random draw, the function resamples until the retained subset yields a full-rank 
+    model matrix and satisfies all cost constraints. If the maximum number of attempts is 
+    reached without finding a fully feasible set, it returns the closest rank-sufficient 
+    attempt, letting the caller decide how to proceed.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        The design DataFrame containing the denormalized factor levels, 
+        optionally with a grouping column
+    group_col : str, optional
+        The column name to group rows by (e.g., a batch or day identifier). If None, 
+        defaults to the run index.
+    n_keep : int, optional
+        The number of groups to retain in the warm start subset. If None, defaults 
+        to half of the unique groups.
+    max_tries : int, default=5000
+        The maximum number of random draws to attempt before yielding the best 
+        infeasible (but full-rank) subset.
+    """
+    def _init_warm_feasible(params):
+        
+        Ydf = df.copy()
+        for f in params.factors:
+            Ydf[f.name] = f.normalize(Ydf[f.name])
+        factor_names = [f.name for f in params.factors]
+        Ydec = Ydf[factor_names].to_numpy()
+        Yenc = encode_design(Ydec, params.effect_types, coords=params.coords)
+
+        if group_col is None:
+            group = list(Ydf.index)
+        else:
+            group = Ydf[group_col].to_numpy()
+
+        groups = np.unique(group)
+        k = n_keep if n_keep is not None else max(1, len(groups) // 2)
+        if k >= len(groups):
+            return Yenc                            # nothing to subsample
+
+        pick = list(combinations(groups, n_keep))
+        pick = np.random.permutation(pick)
+
+        tries = min(max_tries, pick.shape[0])
+
+        best, best_cost = None, None
+        for i in tqdm(range(tries)):
+            mask = np.isin(group, pick[i])
+            Yk = Yenc[mask]
+
+            costs = params.fn.cost(Yk, params)
+            cost_Yk = np.array([np.sum(c) for c, _, _ in costs])
+            max_cost = np.array([m for _, m, _ in costs])
+
+            Xk = params.fn.Y2X(Yk)
+            rank = np.linalg.matrix_rank(Xk)
+            feasible = (rank >= Xk.shape[1]) \
+                    and (np.all(cost_Yk <= max_cost))
+
+            if feasible:
+                return Yk                            # estimable: done
+            
+            elif rank >= Xk.shape[1] and (best is None or np.all(cost_Yk[cost_Yk > max_cost] < best_cost)):
+                best, best_cost = Yk, cost_Yk[cost_Yk > max_cost]
+
+
+        # FINAL CHECKS
+        if best is None:
+            raise ValueError(
+                f"No {k}-group subset achieved full rank in {max_tries} draws "
+                f"(need {Xk.shape[1]} params). Cannot warm start. Try a larger n_keep."
+            )
+        
+        warnings.warn(
+            f"no {k}-group subset reached full rank in {max_tries} draws "
+            f"(need {Xk.shape[1]} params); returning largest attempt ({best.shape[0]} runs). "
+            f"Try a larger n_keep.")
+        return best
+    return _init_warm_feasible


### PR DESCRIPTION
This PR adds a new initialization strategy to init.py for warm starting the optimizer from an existing design.

**What it does:**

- Adds init_warm_feasible, which takes a pandas DataFrame of an existing design and returns a feasible random start.
- Instead of dropping random individual rows (which could orphan half-built batches or interdependent runs), it drops whole groups based on a grouping column (like a day or batch ID).
- Resamples groups until it finds a subset that is both full-rank and cost-feasible.
- Includes fallback logic to return the closest full-rank attempt (along with a warning) if no fully feasible subset is found within max_tries.

**Reason for adding:**
In certain cases, a completely random start fails to find a feasible design even when one mathematically exists. This is especially true for complex cost structures that rely on highly specific run ordering or grouping.

To solve this, this function uses a larger design (previously obtained from a random start with a larger budget) that already contains the specific ordering needed to satisfy the complex costs. By taking random subsamples of this larger design—and keeping intelligent groups intact via the grouping column—we can reliably generate a rank-sufficient and cost-feasible starting point.

**Notes for Review:**

- Added to the bottom of init.py so it doesn't disrupt the existing init_feasible / init_feasible_ functions.
- I added the necessary imports (combinations, warnings, encode_design) to the top of the file as they weren't there yet.
- This is a completely optional function and doesn't affect the rest of the codebase whatsoever. It should be understood as a more advanced setting, in cases where the default initializer fails to return feasible designs.

