### PR TITLE
perf: Skip forced DataFrame conversion in cost functions for lower overhead

### DIFF
--- a/src/pyoptex/doe/cost_optimal/cost.py
+++ b/src/pyoptex/doe/cost_optimal/cost.py
@@ -1,7 +1,7 @@
 """
 Module containing all the cost functions of the cost optimal designs
 """
-
+import warnings
 from functools import partial, wraps
 
 import numba
@@ -31,7 +31,7 @@ def _fn_denormalized(f, Y, params):
         Y[str(f.name)] = f.denormalize(Y[str(f.name)])
     return f(Y, params)
 
-def __cost_fn(f, denormalize=True, decoded=True, dataframe=None, contains_params=False):
+def __cost_fn(f, denormalize=True, decoded=True, dataframe=True, contains_params=False):
     """
     Cost function decorator code.
 
@@ -43,10 +43,8 @@ def __cost_fn(f, denormalize=True, decoded=True, dataframe=None, contains_params
         Whether to denormalize (and decode) the data before passing it to `f`.
     decoded : bool
         Whether to only decode, but not denormalize the data before passing it to `f`.
-    dataframe : bool or None, default None
-        Whether to convert the design to a pandas DataFrame before passing it
-        to the cost function. If None, this defaults to True when
-        `denormalize=True` and False otherwise.
+    dataframe : bool
+        Whether to convert the design to a pandas DataFrame before passing it to `f`.
     contains_params : bool
         Whether the cost function requires the CODEX
         :py:class:`Parameters <pyoptex.doe.cost_optimal.utils.Parameters>`.
@@ -58,12 +56,12 @@ def __cost_fn(f, denormalize=True, decoded=True, dataframe=None, contains_params
         The decorated function
     """
     if denormalize and dataframe is False:
-        raise ValueError(
-            "denormalize=True requires dataframe=True."
+        warnings.warn(
+            "denormalize=True requires DataFrame conversion; "
+            "ignoring dataframe=False.",
+            UserWarning,
         )
-    
-    if dataframe is None:
-        dataframe = denormalize
+        dataframe = True
 
     # Check if parameters are required (prevents direct use of numba.njit compilation)
     if not contains_params:
@@ -111,10 +109,8 @@ def cost_fn(*args, **kwargs):
         Whether to denormalize (and decode) the data before passing it to `f`.
     decoded : bool
         Whether to only decode, but not denormalize the data before passing it to `f`.
-    dataframe : bool or None, default None
-        Whether to convert the design to a pandas DataFrame before passing it
-        to the cost function. If None, this defaults to True when
-        `denormalize=True` and False otherwise.
+    dataframe : bool
+        Whether to convert the design to a pandas DataFrame before passing it to `f`.
     contains_params : bool
         Whether the cost function requires the
         :py:class:`Parameters <pyoptex.doe.cost_optimal.utils.Parameters>`.

--- a/src/pyoptex/doe/cost_optimal/cost.py
+++ b/src/pyoptex/doe/cost_optimal/cost.py
@@ -27,11 +27,11 @@ def _fn_as_dataframe(f, Y, params):
     return f(Y, params)
 
 def _fn_denormalized(f, Y, params):
-    for f in params.factors:
-        Y[str(f.name)] = f.denormalize(Y[str(f.name)])
+    for factor in params.factors:
+        Y[str(factor.name)] = factor.denormalize(Y[str(factor.name)])
     return f(Y, params)
 
-def __cost_fn(f, denormalize=True, decoded=True, dataframe=True, contains_params=False):
+def __cost_fn(f, denormalize=True, decoded=True, dataframe=None, contains_params=False):
     """
     Cost function decorator code.
 
@@ -43,8 +43,10 @@ def __cost_fn(f, denormalize=True, decoded=True, dataframe=True, contains_params
         Whether to denormalize (and decode) the data before passing it to `f`.
     decoded : bool
         Whether to only decode, but not denormalize the data before passing it to `f`.
-    dataframe : bool
-        Whether to convert the design to a pandas DataFrame before passing it to `f`.
+    dataframe : bool or None, default None
+        Whether to convert the design to a pandas DataFrame before passing it to `f`. 
+        If None, this defaults to True when `denormalize=True` or `decoded=True`
+        and False otherwise.
     contains_params : bool
         Whether the cost function requires the CODEX
         :py:class:`Parameters <pyoptex.doe.cost_optimal.utils.Parameters>`.
@@ -62,6 +64,9 @@ def __cost_fn(f, denormalize=True, decoded=True, dataframe=True, contains_params
             UserWarning,
         )
         dataframe = True
+    
+    if dataframe is None:
+        dataframe = denormalize or decoded
 
     # Check if parameters are required (prevents direct use of numba.njit compilation)
     if not contains_params:
@@ -109,8 +114,10 @@ def cost_fn(*args, **kwargs):
         Whether to denormalize (and decode) the data before passing it to `f`.
     decoded : bool
         Whether to only decode, but not denormalize the data before passing it to `f`.
-    dataframe : bool
-        Whether to convert the design to a pandas DataFrame before passing it to `f`.
+    dataframe : bool or None, default None
+        Whether to convert the design to a pandas DataFrame before passing it to `f`. 
+        If None, this defaults to True when `denormalize=True` or `decoded=True` 
+        and False otherwise.
     contains_params : bool
         Whether the cost function requires the
         :py:class:`Parameters <pyoptex.doe.cost_optimal.utils.Parameters>`.

--- a/src/pyoptex/doe/cost_optimal/cost.py
+++ b/src/pyoptex/doe/cost_optimal/cost.py
@@ -16,22 +16,22 @@ def _fn_no_params(f, Y, params):
 
 
 def _fn_decoded(f, Y, params):
-    # Decode the design to a dataframe
     Y = decode_design(Y, params.effect_types, coords=params.coords)
-    Y = pd.DataFrame(Y, columns=[str(f.name) for f in params.factors])
     return f(Y, params)
 
+def _fn_as_dataframe(f, Y, params):
+    Y = pd.DataFrame(
+        Y,
+        columns=[str(factor.name) for factor in params.factors]
+    )
+    return f(Y, params)
 
 def _fn_denormalized(f, Y, params):
-    # Decode the design to a dataframe
-    Y = decode_design(Y, params.effect_types, coords=params.coords)
-    Y = pd.DataFrame(Y, columns=[str(f.name) for f in params.factors])
     for f in params.factors:
         Y[str(f.name)] = f.denormalize(Y[str(f.name)])
     return f(Y, params)
 
-
-def __cost_fn(f, denormalize=True, decoded=True, contains_params=False):
+def __cost_fn(f, denormalize=True, decoded=True, dataframe=None, contains_params=False):
     """
     Cost function decorator code.
 
@@ -43,6 +43,10 @@ def __cost_fn(f, denormalize=True, decoded=True, contains_params=False):
         Whether to denormalize (and decode) the data before passing it to `f`.
     decoded : bool
         Whether to only decode, but not denormalize the data before passing it to `f`.
+    dataframe : bool or None, default None
+        Whether to convert the design to a pandas DataFrame before passing it
+        to the cost function. If None, this defaults to True when
+        `denormalize=True` and False otherwise.
     contains_params : bool
         Whether the cost function requires the CODEX
         :py:class:`Parameters <pyoptex.doe.cost_optimal.utils.Parameters>`.
@@ -53,29 +57,44 @@ def __cost_fn(f, denormalize=True, decoded=True, contains_params=False):
     fn : func(Y, params)
         The decorated function
     """
+    if denormalize and dataframe is False:
+        raise ValueError(
+            "denormalize=True requires dataframe=True."
+        )
+    
+    if dataframe is None:
+        dataframe = denormalize
 
     # Check if parameters are required (prevents direct use of numba.njit compilation)
     if not contains_params:
         f = wraps(f)(partial(_fn_no_params, f))
 
-    # Check for denormalization in the cost function
+    # Decode categorical variables first
+    if denormalize or decoded:
+        f = wraps(f)(partial(_fn_decoded, f))
+
+    # Convert to DataFrame if requested
+    if dataframe:
+        f = wraps(f)(partial(_fn_as_dataframe, f))
+
+    # Denormalize numerical factors
     if denormalize:
-        # Wrap the function
         f = wraps(f)(partial(_fn_denormalized, f))
         NOTE = "This cost function works on denormalized inputs"
 
     elif decoded:
-        # Wrap the function
-        f = wraps(f)(partial(_fn_decoded, f))
         NOTE = "This cost function works on decoded categorical inputs"
 
     else:
         NOTE = "This cost function works on normalized (encoded) inputs"
 
-    # Extend the documentation with a note on normalization
     if f.__doc__ is not None:
         params_pos = f.__doc__.find("    Parameters\n    ---------")
-        f.__doc__ = f.__doc__[:params_pos] + f"\n    .. note::\n        {NOTE}\n\n" + f.__doc__[params_pos:]
+        f.__doc__ = (
+            f.__doc__[:params_pos]
+            + f"\n    .. note::\n        {NOTE}\n\n"
+            + f.__doc__[params_pos:]
+        )
 
     return f
 
@@ -92,6 +111,10 @@ def cost_fn(*args, **kwargs):
         Whether to denormalize (and decode) the data before passing it to `f`.
     decoded : bool
         Whether to only decode, but not denormalize the data before passing it to `f`.
+    dataframe : bool or None, default None
+        Whether to convert the design to a pandas DataFrame before passing it
+        to the cost function. If None, this defaults to True when
+        `denormalize=True` and False otherwise.
     contains_params : bool
         Whether the cost function requires the
         :py:class:`Parameters <pyoptex.doe.cost_optimal.utils.Parameters>`.


### PR DESCRIPTION
**Description:**

This PR optimizes the @cost_fn decorator by removing the forced Pandas DataFrame conversion when working with decoded data.

**What it does:**

- Extracts the DataFrame conversion logic into a separate _fn_as_dataframe wrapper.
- Introduces a dataframe parameter to @cost_fn and __cost_fn.
- If a user specifies decoded=True and dataframe=False, the cost function will now receive a raw decoded numpy array instead of a Pandas DataFrame.
- Adds a safeguard: denormalize=True explicitly checks for and requires dataframe=True (since denormalization relies on string-based column indexing).

**Reason for adding:**
Previously, any cost function requesting decoded inputs was forced to take a Pandas DataFrame. Because the cost function is called continuously during the optimization loop, instantiating a new DataFrame, even when not necessary, on every single evaluation adds severe computational overhead.

Many custom cost functions rely strictly on numpy arrays anyway. Decoupling the DataFrame conversion allows these functions to run much faster without unnecessary type casting.

**Notes for Review:**
- Default behavior is preserved: dataframe=None automatically resolves to True when denormalize=True.
- The documentation generation logic was slightly updated to handle the new execution order of the wrappers.