### PR TITLE
Relax constraint validation on prior data to allow deprecated factor levels

### DIFF
--- a/src/pyoptex/doe/cost_optimal/codex/wrapper.py
+++ b/src/pyoptex/doe/cost_optimal/codex/wrapper.py
@@ -1,6 +1,7 @@
 """
 Module for the interface to run the CODEX algorithm
 """
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -201,7 +202,8 @@ def create_parameters(factors, fn, prior=None, use_formulas=True):
         prior = encode_design(prior, effect_types, coords=coords)
 
         # Validate prior
-        assert not np.any(fn.constraints(prior)), "Prior contains constraint violating runs"
+        if np.any(fn.constraints(prior)):
+            warnings.warn("Prior contains constraint violating runs", UserWarning)
         fn.constraints.clear()  # Clear to permit pickling for multiprocessing
 
     else:

--- a/src/pyoptex/doe/cost_optimal/validation.py
+++ b/src/pyoptex/doe/cost_optimal/validation.py
@@ -26,7 +26,7 @@ def validate_state(state, params, eps=1e-6):
     """
 
     # Make sure all runs are possible
-    constraints = params.fn.constraints(state.Y)
+    constraints = params.fn.constraints(state.Y[len(params.prior):])
     assert not np.any(constraints), f"(validation) Constraints of Y are violated: {constraints}"
 
     # Make sure the prior is at the start


### PR DESCRIPTION

**Description:**
Previously, the code strictly asserted that all data—including user-supplied prior data—met the current design constraints. However, sometimes a previous design contains factor levels that have since been deemed unnecessary and shouldn't end up in subsequent design augmentations, even though they should still be taken into account for the model.

This PR introduces a compromise to handle this edge case gracefully without breaking the workflow.

**Changes:**
- Warn instead of fail on prior: Converted the strict assertion on fn.constraints(prior) into a UserWarning. This surfaces the issue to the user so they are aware of the violating runs, but allows them to proceed.
- Scope strict validation to new augmentations: Modified the state.Y constraint assertion to only validate state.Y[len(params.prior):]. This ensures that any newly generated design augmentations strictly adhere to the constraints, while giving a pass to the legacy prior data.